### PR TITLE
16.0 fix mcurr tests

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -1048,7 +1048,7 @@ class AccountBankStatementLine(models.Model):
                 self.company_id,
                 self.date,
             )
-        return to_amount - amount
+        return self.company_id.currency_id.round(to_amount - amount)
 
     def _compute_exchange_rate(
         self,

--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -425,6 +425,10 @@ class AccountBankStatementLine(models.Model):
         for line in data:
             if line["reference"] == self.manual_reference:
                 if self._check_line_changed(line):
+                    if line["line_currency_id"] == self.company_id.currency_id.id:
+                        currency_amount = self.manual_amount
+                    else:
+                        currency_amount = self.manual_amount_in_currency
                     line.update(
                         {
                             "name": self.manual_name,
@@ -442,7 +446,7 @@ class AccountBankStatementLine(models.Model):
                             if self.manual_amount > 0
                             else 0.0,
                             "analytic_distribution": self.analytic_distribution,
-                            "currency_amount": self.manual_amount_in_currency,
+                            "currency_amount": currency_amount,
                             "kind": line["kind"]
                             if line["kind"] != "suspense"
                             else "other",

--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -74,7 +74,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         inv1 = self.create_invoice(currency_id=self.currency_usd_id, invoice_amount=100)
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
                 "journal_id": self.bank_journal_euro.id,
                 "date": time.strftime("%Y-07-15"),
                 "name": "test",
@@ -102,6 +101,42 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             self.assertFalse(f.add_account_move_line_id)
             self.assertTrue(f.can_reconcile)
 
+    def test_manual_line_with_currency(self):
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": self.bank_journal_euro.id,
+                "date": time.strftime("%Y-07-15"),
+                "name": "test",
+            }
+        )
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "testLine",
+                "journal_id": self.bank_journal_euro.id,
+                "statement_id": bank_stmt.id,
+                "amount": 50,
+                "amount_currency": 100,
+                "foreign_currency_id": self.currency_usd_id,
+                "date": time.strftime("%Y-07-15"),
+            }
+        )
+        receivable_acc = self.company_data["default_account_receivable"]
+        with Form(
+            bank_stmt_line,
+            view="account_reconcile_oca.bank_statement_line_form_reconcile_view",
+        ) as f:
+            self.assertFalse(f.can_reconcile)
+            f.manual_reference = "reconcile_auxiliary;1"
+            f.manual_account_id = receivable_acc
+            self.assertTrue(f.can_reconcile)
+        bank_stmt_line.reconcile_bank_line()
+        receivable_line = bank_stmt_line.line_ids.filtered(
+            lambda line: line.account_id == receivable_acc
+        )
+        self.assertEqual(receivable_line.currency_id.id, self.currency_usd_id)
+        self.assertEqual(receivable_line.amount_currency, -100)
+        self.assertEqual(receivable_line.balance, -50)
+
     def test_reconcile_invoice_reconcile_full(self):
         """
         We want to test the reconcile widget for bank statements on invoices.
@@ -113,7 +148,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         )
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
                 "journal_id": self.bank_journal_euro.id,
                 "date": time.strftime("%Y-07-15"),
                 "name": "test",
@@ -162,7 +196,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         )
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
                 "journal_id": self.bank_journal_euro.id,
                 "date": time.strftime("%Y-07-15"),
                 "name": "test",
@@ -225,7 +258,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         )
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
                 "journal_id": self.bank_journal_euro.id,
                 "date": time.strftime("%Y-07-15"),
                 "name": "test",
@@ -289,7 +321,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         )
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
                 "journal_id": self.bank_journal_euro.id,
                 "date": time.strftime("%Y-07-15"),
                 "name": "test",
@@ -343,7 +374,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         """
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
                 "journal_id": self.bank_journal_euro.id,
                 "date": time.strftime("%Y-07-15"),
                 "name": "test",
@@ -387,7 +417,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         )
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
                 "journal_id": self.bank_journal_euro.id,
                 "date": time.strftime("%Y-07-15"),
                 "name": "test",
@@ -442,7 +471,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         )
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
                 "journal_id": self.bank_journal_euro.id,
                 "date": time.strftime("%Y-07-15"),
                 "name": "test",
@@ -502,7 +530,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
 
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
                 "journal_id": self.bank_journal_euro.id,
                 "date": time.strftime("%Y-07-15"),
                 "name": "test",
@@ -532,7 +559,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         )
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
                 "journal_id": self.bank_journal_euro.id,
                 "date": time.strftime("%Y-07-15"),
                 "name": "test",
@@ -590,7 +616,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         )
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
                 "journal_id": self.bank_journal_euro.id,
                 "date": time.strftime("%Y-07-15"),
                 "name": "test",
@@ -632,7 +657,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         """
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
                 "journal_id": self.bank_journal_euro.id,
                 "date": time.strftime("%Y-07-15"),
                 "name": "test",
@@ -667,7 +691,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         )
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
                 "journal_id": self.bank_journal_euro.id,
                 "date": time.strftime("%Y-07-15"),
                 "name": "test",
@@ -705,7 +728,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         )
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
                 "journal_id": self.bank_journal_euro.id,
                 "date": time.strftime("%Y-07-15"),
                 "name": "test",
@@ -746,7 +768,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         )
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
                 "journal_id": self.bank_journal_euro.id,
                 "date": time.strftime("%Y-07-15"),
                 "name": "test",
@@ -787,7 +808,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         )
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
                 "journal_id": self.bank_journal_euro.id,
                 "date": time.strftime("%Y-07-15"),
                 "name": "test",
@@ -823,7 +843,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         """
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
                 "journal_id": self.bank_journal_euro.id,
                 "date": time.strftime("%Y-07-15"),
                 "name": "test",
@@ -874,7 +893,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         """
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
                 "journal_id": self.bank_journal_euro.id,
                 "date": time.strftime("%Y-07-15"),
                 "name": "test",
@@ -917,7 +935,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
 
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
                 "journal_id": self.bank_journal_euro.id,
                 "date": time.strftime("%Y-07-15"),
                 "name": "test",
@@ -981,7 +998,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
 
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
                 "journal_id": self.bank_journal_euro.id,
                 "date": time.strftime("%Y-07-15"),
                 "name": "test",
@@ -1013,7 +1029,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         inv1 = self.create_invoice(currency_id=self.currency_usd_id, invoice_amount=100)
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
                 "journal_id": self.bank_journal_usd.id,
                 "date": time.strftime("%Y-07-15"),
                 "name": "test",
@@ -1052,29 +1067,50 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         )
 
     def test_journal_foreign_currency_change(self):
+        cny = self.env.ref("base.CNY")
+        cny.write({"active": True})
+        cny_journal = self.env["account.journal"].create(
+            {
+                "name": "Bank CNY",
+                "type": "bank",
+                "currency_id": cny.id,
+            }
+        )
         self.env["res.currency.rate"].create(
             {
-                "currency_id": self.env.ref("base.EUR").id,
-                "name": time.strftime("%Y-07-14"),
-                "rate": 1.15,
+                "name": time.strftime("%Y-09-10"),
+                "currency_id": cny.id,
+                "inverse_company_rate": 0.125989013758,
+            }
+        )
+        self.env["res.currency.rate"].create(
+            {
+                "name": time.strftime("%Y-09-09"),
+                "currency_id": cny.id,
+                "inverse_company_rate": 0.126225969731,
             }
         )
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
-                "journal_id": self.bank_journal_usd.id,
-                "date": time.strftime("%Y-07-15"),
+                "journal_id": cny_journal.id,
+                "date": time.strftime("%Y-09-10"),
                 "name": "test",
             }
         )
         bank_stmt_line = self.acc_bank_stmt_line_model.create(
             {
                 "name": "testLine",
-                "journal_id": self.bank_journal_usd.id,
+                "journal_id": cny_journal.id,
                 "statement_id": bank_stmt.id,
-                "amount": 100,
-                "date": time.strftime("%Y-07-15"),
+                "amount": 259200,
+                "date": time.strftime("%Y-09-10"),
             }
+        )
+        inv1 = self._create_invoice(
+            currency_id=cny.id,
+            invoice_amount=259200,
+            date_invoice=time.strftime("%Y-09-09"),
+            auto_validate=True,
         )
         with Form(
             bank_stmt_line,
@@ -1083,24 +1119,17 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             line = f.reconcile_data_info["data"][0]
             self.assertEqual(
                 line["currency_amount"],
-                100,
+                259200,
             )
-        self.env["res.currency.rate"].create(
-            {
-                "currency_id": self.env.ref("base.EUR").id,
-                "name": time.strftime("%Y-07-15"),
-                "rate": 1.2,
-            }
-        )
-        with Form(
-            bank_stmt_line,
-            view="account_reconcile_oca.bank_statement_line_form_reconcile_view",
-        ) as f:
-            line = f.reconcile_data_info["data"][0]
-            self.assertEqual(
-                line["currency_amount"],
-                100,
+            f.add_account_move_line_id = inv1.line_ids.filtered(
+                lambda l: l.account_id.account_type == "asset_receivable"
             )
+            self.assertTrue(f.can_reconcile)
+        self.assertEqual(len(bank_stmt_line.reconcile_data_info["data"]), 3)
+        exchange_line = bank_stmt_line.reconcile_data_info["data"][-1]
+        self.assertEqual(exchange_line["amount"], 61.42)
+        bank_stmt_line.reconcile_bank_line()
+        self.assertEqual(inv1.payment_state, "paid")
 
     def test_invoice_foreign_currency_change(self):
         self.env["res.currency.rate"].create(
@@ -1125,7 +1154,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         )
         bank_stmt = self.acc_bank_stmt_model.create(
             {
-                "company_id": self.env.ref("base.main_company").id,
                 "journal_id": self.bank_journal_usd.id,
                 "date": time.strftime("%Y-07-15"),
                 "name": "test",


### PR DESCRIPTION
@etobella 

This PR fix the failing test of this PR : https://github.com/OCA/account-reconcile/pull/694
The failing tests made me see that were still basic bugs, I had to do quite some change again.
Now tests are fixed, I still need to add tests for some basic use cases of multi-currency management.

Still, I am quite sure there will still exist issue with some less comon cases.
Also, I saw that the mutli-currency reconciliation was also broken when trying to do it directly from account move lines, because most of the implemented logic is on `account.bank.statement.line`
But I don't intend to work on that part, at least not in the short term...

let's talk a bit about this PR tomorrow if you have some time.
I'll try to add some tests tomorrow also if I have the time !